### PR TITLE
Add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,56 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v2.1.0
+  hooks:
+  - id: check-yaml
+  - id: debug-statements
+  - id: name-tests-test
+  - id: requirements-txt-fixer
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-docstring-first
+  - id: double-quote-string-fixer
+  - id: check-ast
+  - id: no-commit-to-branch
+  - id: check-merge-conflict
+
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.7.2
+  hooks:
+  - id: flake8
+
+- repo: https://github.com/asottile/add-trailing-comma
+  rev: v1.2.0
+  hooks:
+  - id: add-trailing-comma
+
+- repo: https://github.com/Lucas-C/pre-commit-hooks
+  rev: v1.1.6
+  hooks:
+  - id: forbid-crlf
+  - id: remove-crlf
+  - id: forbid-tabs
+  - id: remove-tabs
+    args: [ --whitespaces-count, '4' ]  # defaults to: 4
+
+- repo: git://github.com/chewse/pre-commit-mirrors-pydocstyle
+  rev: 22d3ccf
+  hooks:
+  - id: pydocstyle
+    exclude: blog/migrations/
+
+- repo: https://github.com/pre-commit/mirrors-mypy
+  rev: v0.701
+  hooks:
+  - id: mypy
+
+- repo: local
+  hooks:
+  - id: pylint
+    language: system
+    name: PyLint
+    files: \.py$
+    entry: python3 -m pylint.__main__
+    args:
+    - --good-names=urlpatterns
+    exclude: blog/migrations/


### PR DESCRIPTION
Closes #1 

Ref: https://pre-commit.com

This commit includes the initial configuration for
the following pre-commit hooks:

    no-commit-to-branch
    add-trailing-comma
    remove-tabs
    trailing-whitespace
    check-merge-conflict
    double-quote-string-fixer
    requirements-txt-fixer
    check-yaml
    check-docstring-first
    end-of-file-fixer
    name-tests-test
    check-ast
    debug-statements
    flake8
    pydocstyle
    pylint using "local" mode
    mypy
